### PR TITLE
Add vagrant plugin prerequisites to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,8 @@ Testing
 
 To test this App::
 
+    $ vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
+    $ vagrant plugin install vagrant-omnibus
     $ vagrant up
     $ make test
 


### PR DESCRIPTION
The `vagrant-berkshelf` and `vagrant-omnibus` plugins are required to bring the test box up.
