### PR TITLE
Minor changes so that graphite.py works in Splunk 8.2 under Python 3.

### DIFF
--- a/bin/graphite.py
+++ b/bin/graphite.py
@@ -17,7 +17,7 @@ __license__ = 'Apache License, Version 2.0'
 
 
 import argparse
-import ConfigParser
+import configparser
 import csv
 import gzip
 import os
@@ -93,7 +93,7 @@ def get_graphite_config(config_file, args=None):
         }
 
     if config_file and os.path.exists(config_file):
-        config = ConfigParser.SafeConfigParser(graphite_config)
+        config = configparser.ConfigParser(delimiters=('='), strict=False).SafeConfigParser(graphite_config)
         config.read(config_file)
 
         # Cast ConfigParser.items()'s list of tuples into dict:
@@ -264,7 +264,7 @@ def send_metrics(metrics, host, port):
         sock = socket.socket()
         sock.settimeout(6)
         sock.connect((host, int(port)))
-        sock.sendall('\n'.join(metrics) + '\n')
+        sock.sendall(('\n'.join(metrics) + '\n').encode())
         sock.shutdown(1)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -185,12 +185,12 @@ class TestSplunkGraphiteApp(unittest.TestCase):  # pylint: disable=R0904
             fabric.contrib.files.append(log_file, log_line, use_sudo=True)
             nc_return = fabric.api.run('nc -l 2003')
             test_str = "test_metric %s" % rand_int
-            print "nc_return----"
-            print nc_return
-            print "---"
-            print dir(nc_return)
-            print "nc_return----"
-            print test_str in nc_return.stdout
+            print("nc_return----")
+            print(nc_return)
+            print("---")
+            print(dir(nc_return))
+            print("nc_return----")
+            print(test_str in nc_return.stdout)
             self.assertTrue(test_str in nc_return.stdout)
 
     def test_unconfigured_app(self):


### PR DESCRIPTION
I'm not familiar with Vagrant so I wasn't able to quickly get the tests up and running. I made the changes in this branch and verified that it works in a local Splunk 8.2.1 node. I haven't incremented the version number, or anything else.

If you have an interest in merging and releasing to SplunkBase, that'll be great. Otherwise not to worry, I'll use my fork.